### PR TITLE
Fix issue #5 - The tool assert(0) on count > 10

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -16,6 +16,7 @@
 module faucet.main;
 
 import agora.api.FullNode;
+import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Serializer;
 import agora.common.Types;
@@ -106,7 +107,9 @@ private auto splitTx (UR) (UR utxo_rng, uint count)
 {
     static assert (isInputRange!UR);
 
-    return utxo_rng.map!(tup => buildTx(tup.value.output, tup.key))
+    return utxo_rng
+        .filter!(tup => tup.value.output.value >= Amount(count))
+        .map!(tup => buildTx(tup.value.output, tup.key))
         .map!(txb => txb.split(
                   WK.Keys.byRange()
                   .drop(uniform(0, 1378 - count, rndGen))


### PR DESCRIPTION
```
The solution is simply to skip the UTXOs which would cause the assert.
However we'll soon run into another problem - we'll run out of UTXOs.
```

Also contains a submodule update that has been deployed live already.