### PR TITLE
Use `updateUTXOCache` instead of `put`

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -22,7 +22,6 @@ import agora.common.Serializer;
 import agora.common.Types;
 import agora.consensus.data.genesis.Test;
 import agora.consensus.data.Transaction;
-import agora.consensus.data.UTXO;
 import agora.consensus.state.UTXOSet;
 import agora.utils.Test;
 

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -67,7 +67,7 @@ private struct State
         foreach (ref b; blocks)
             foreach (ref tx; b.txs)
                 if (tx.type == TxType.Payment)
-                    this.utxos.put(tx);
+                    this.utxos.updateUTXOCache(tx, b.header.height);
 
         // Use signed arithmetic to avoid negative values wrapping around
         const long delta = (cast(long) this.utxos.storage.length) - current_len;


### PR DESCRIPTION
The `updateUTXOCache` function is now available to the `TestUTXOSet`.
This clears used `UTXO`s in addition to adding new ones.

Fixed by #10, [agora#1318](https://github.com/bpfkorea/agora/pull/1318)