### PR TITLE
Update functions to merge transactions properly

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -41,7 +41,7 @@ import vibe.web.rest;
 private struct Config
 {
     /// How frequently we run our periodic task
-    static immutable interval = 15.seconds;
+    static immutable interval = 30.seconds;
 
     /// Between how many addresses we split a transaction by
     static immutable count = 15;


### PR DESCRIPTION
The `mergeTx` function was creating the same number of `Output`s as `Input`s so it was not actually merging.
We decide to either split or merge based on the number of `UTXO`, and these functions adjust the number. Merging should decrease the number of `UTXO` by definition as below :

```
[main(J2TR) INF] UTXO delta: -15
```
The most basic way (current implementation) is to create a single `Transaction` with multiple `Input`s and a single `Output`.

Also, `filter` should have been called in `splitTx` instead of `mergeTx`. Its role is to skip splitting `Output`s with `Amount` less than `count` so we don't end up with `Amount(0)`.