### PR TITLE
Implement a basic API

### DIFF
--- a/source/faucet/api.d
+++ b/source/faucet/api.d
@@ -33,4 +33,18 @@ import vibe.http.common;
 @path("/")
 public interface IFaucet
 {
+// The REST generator requires @safe methods
+@safe:
+
+    /***************************************************************************
+
+        Returns:
+          An array of all UTXOs known
+
+        API:
+          GET /utxos
+
+    ***************************************************************************/
+
+    public UTXO[Hash] getUTXOs ();
 }

--- a/source/faucet/api.d
+++ b/source/faucet/api.d
@@ -1,0 +1,36 @@
+/*******************************************************************************
+
+    Definitions of the faucet API
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module faucet.api;
+
+import agora.common.Hash;
+import agora.consensus.state.UTXOSet;
+
+import vibe.web.rest;
+import vibe.http.common;
+
+/*******************************************************************************
+
+    Define the API the faucet exposes to the world
+
+    The faucet can:
+    - Return an array of all UTXOs known
+    - Send `Amount` BOA to `KEY`, using owned UTXOs
+    - Make `Transaction`s
+
+*******************************************************************************/
+
+@path("/")
+public interface IFaucet
+{
+}

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -260,6 +260,12 @@ public class Faucet : IFaucet
             }
         }
     }
+
+    /// GET: /utxos
+    public override UTXO[Hash] getUTXOs () pure nothrow @safe
+    {
+        return this.state.utxos.storage;
+    }
 }
 
 /// Application entry point


### PR DESCRIPTION
The basic structure of a `Faucet API` has been implemented.
Faucet should expose a basic API so it can be called from a frontend service (website) to make `Transaction`s.

`getUTXOs` performs a HTTP `GET /utxos` and returns an array of all UTXOs known.

Part of faucet #15