### PR TITLE
 Expose `sendTransaction` endpoint

### DIFF
--- a/source/faucet/api.d
+++ b/source/faucet/api.d
@@ -13,6 +13,8 @@
 
 module faucet.api;
 
+import agora.common.Amount;
+import agora.common.crypto.Key;
 import agora.common.Hash;
 import agora.consensus.state.UTXOSet;
 
@@ -47,4 +49,19 @@ public interface IFaucet
     ***************************************************************************/
 
     public UTXO[Hash] getUTXOs ();
+
+    /***************************************************************************
+
+        Send `amount` BOA to `KEY`, using owned UTXOs
+
+        API:
+          POST /send_transaction
+
+        Params:
+          recv = the destination key
+          amount = amount of BOA
+
+    ***************************************************************************/
+
+    public void sendTransaction (string recv, ulong amount);
 }


### PR DESCRIPTION
`Faucet` should expose a basic API so it can be called from a frontend service (website) to make `Transaction`s.

The endpoint `POST /send?recv=KEY&amount=1234` sends `amount` BOA to `KEY`, using owned UTXOs.

The API picks one owned UTXO from the storage. If `amount`  <= `UTXO` amount then the `amount` is [drawn](https://github.com/bpfkorea/agora/blob/b6c7b12b9c8dc3fbc88f6e3f8c8dbefd29af5a08/source/agora/utils/Test.d#L529). 
If `amount` > `UTXO` amount then a new `UTXO` is attached and drawn. This repeats until there is a remainder.


Part of #15 