### PR TITLE
Fix syntax error in Github CI configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,6 @@ jobs:
         sudo apt-get install libsodium-dev
 
     - name: Test compilation
-       env:
-         - AGORA_VERSION: HEAD
-       run: dub build
+      env:
+        - AGORA_VERSION: HEAD
+      run: dub build


### PR DESCRIPTION
Significant whitespace was a wonderful idea.