### PR TITLE
Trivial: Update API names

### DIFF
--- a/source/faucet/api.d
+++ b/source/faucet/api.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-module faucet.api;
+module faucet.API;
 
 import agora.common.Amount;
 import agora.common.crypto.Key;
@@ -33,7 +33,7 @@ import vibe.http.common;
 *******************************************************************************/
 
 @path("/")
-public interface IFaucet
+public interface FaucetAPI
 {
 // The REST generator requires @safe methods
 @safe:

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -15,7 +15,7 @@
 
 module faucet.main;
 
-import faucet.api;
+import faucet.API;
 
 import agora.api.FullNode;
 import agora.common.Amount;
@@ -38,7 +38,6 @@ import core.time;
 import vibe.core.core;
 import vibe.core.log;
 import vibe.web.rest;
-
 
 /// Configuration parameter for Faucet
 private struct Config
@@ -120,7 +119,7 @@ private struct State
 
 *******************************************************************************/
 
-public class Faucet : IFaucet
+public class Faucet : FaucetAPI
 {
     /// Config instance
     private Config config;


### PR DESCRIPTION
The interface name has been changed to use `API`.